### PR TITLE
Fix Prisma schema and harden admin pages for type-safe builds

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,10 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    serverActions: true
-  },
-  output: 'standalone'
+  output: "standalone"
 };
 
 export default nextConfig;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 datasource db {
   provider   = "postgresql"
   url        = env("DATABASE_URL")
-  extensions = [ { name = "pgcrypto" } ]
 }
 
 enum Language {
@@ -46,6 +45,7 @@ model User {
   courseAuthors  CourseAuthor[]
   teamsOwned     Team[]          @relation("TeamOwner")
   teamMembers    TeamMember[]
+  enrollments    Enrollment[]
 }
 
 /// Teams (Groups) for sharing content within a private cohort

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,6 +1,8 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@lib/auth";
 
+export const dynamic = "force-dynamic";
+
 export default async function AdminPage() {
   const session = await getServerSession(authOptions);
   const role = (session?.user as any)?.role ?? "guest";

--- a/apps/web/src/app/admin/requests/page.tsx
+++ b/apps/web/src/app/admin/requests/page.tsx
@@ -2,33 +2,35 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@lib/auth";
 import { prisma } from "@lib/prisma";
 import { revalidatePath } from "next/cache";
+import type { Prisma } from "@prisma/client";
 
-async function updateStatusAction(formData: FormData) {
+export const dynamic = "force-dynamic";
+
+async function updateStatusAction(formData: FormData): Promise<void> {
   "use server";
   const id = String(formData.get("id") || "");
   const status = String(formData.get("status") || "new");
-  if (!id) return { ok: false };
+  if (!id) return;
   await prisma.requestAccess.update({ where: { id }, data: { status } }).catch(() => {});
   revalidatePath("/admin/requests");
-  return { ok: true };
 }
 
-async function deleteAction(formData: FormData) {
+async function deleteAction(formData: FormData): Promise<void> {
   "use server";
   const id = String(formData.get("id") || "");
-  if (!id) return { ok: false };
+  if (!id) return;
   await prisma.requestAccess.delete({ where: { id } }).catch(() => {});
   revalidatePath("/admin/requests");
-  return { ok: true };
 }
 
 async function getData(q: string | null, status: string | null, page = 1, perPage = 20) {
-  const where: any = {};
+  const insensitive: Prisma.QueryMode = "insensitive";
+  const where: Prisma.RequestAccessWhereInput = {};
   if (q) {
     where.OR = [
-      { email: { contains: q, mode: "insensitive" } },
-      { name: { contains: q, mode: "insensitive" } },
-      { organization: { contains: q, mode: "insensitive" } }
+      { email: { contains: q, mode: insensitive } },
+      { name: { contains: q, mode: insensitive } },
+      { organization: { contains: q, mode: insensitive } }
     ];
   }
   if (status && status !== "all") {

--- a/apps/web/src/app/api/ai-assistant/message/route.ts
+++ b/apps/web/src/app/api/ai-assistant/message/route.ts
@@ -28,10 +28,13 @@ export async function POST(req: Request) {
         "Always remind to consult clinical guidelines and use clinical judgment."
     };
 
-    const normalized: AIMessage[] = [sys, ...messages.map((m: any) => ({
-      role: m.role === "assistant" ? "assistant" : m.role === "system" ? "system" : "user",
-      content: String(m.content ?? "")
-    }))];
+    const normalized: AIMessage[] = [
+      sys,
+      ...messages.map((m: any): AIMessage => ({
+        role: m.role === "assistant" ? "assistant" : m.role === "system" ? "system" : "user",
+        content: String(m.content ?? "")
+      }))
+    ];
 
     const result = await chat({
       messages: normalized,

--- a/apps/web/src/app/author/page.tsx
+++ b/apps/web/src/app/author/page.tsx
@@ -1,6 +1,8 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@lib/auth";
 
+export const dynamic = "force-dynamic";
+
 export default async function AuthorHome() {
   const session = await getServerSession(authOptions);
 

--- a/apps/web/src/app/conditions/page.tsx
+++ b/apps/web/src/app/conditions/page.tsx
@@ -1,15 +1,17 @@
 import { prisma } from "@lib/prisma";
+import type { Prisma } from "@prisma/client";
 
 async function getData(q: string | null, limit = 200) {
   try {
-    const where = q
+    const insensitive: Prisma.QueryMode = "insensitive";
+    const where: Prisma.ConditionWhereInput | undefined = q
       ? {
           OR: [
-            { name: { contains: q, mode: "insensitive" } },
-            { slug: { contains: q, mode: "insensitive" } }
+            { name: { contains: q, mode: insensitive } },
+            { slug: { contains: q, mode: insensitive } }
           ]
         }
-      : {};
+      : undefined;
     const [items, total] = await Promise.all([
       prisma.condition.findMany({
         where,

--- a/apps/web/src/app/courses/page.tsx
+++ b/apps/web/src/app/courses/page.tsx
@@ -1,15 +1,17 @@
 import { prisma } from "@lib/prisma";
+import type { Prisma } from "@prisma/client";
 
 async function getData(q: string | null, limit = 200) {
   try {
-    const where = q
+    const insensitive: Prisma.QueryMode = "insensitive";
+    const where: Prisma.CourseWhereInput | undefined = q
       ? {
           OR: [
-            { title: { contains: q, mode: "insensitive" } },
-            { provider: { contains: q, mode: "insensitive" } }
+            { title: { contains: q, mode: insensitive } },
+            { provider: { contains: q, mode: insensitive } }
           ]
         }
-      : {};
+      : undefined;
     const [items, total] = await Promise.all([
       prisma.course.findMany({
         where,
@@ -61,11 +63,13 @@ export default async function CoursesPage({ searchParams }: { searchParams?: { q
             <div style={{ color: "#6b7280", fontSize: 12, marginTop: 2 }}>
               {c.provider} • {c.language?.toUpperCase() || "RO"} • {c.specialty?.name ?? "General"}
             </div>
-            <div style={{ marginTop: 8 }}>
-              <a href={c.url} target="_blank" style={{ color: "#2563eb" }} rel="noreferrer">
-                Deschide pagina cursului →
-              </a>
-            </div>
+            {c.url ? (
+              <div style={{ marginTop: 8 }}>
+                <a href={c.url} target="_blank" style={{ color: "#2563eb" }} rel="noreferrer">
+                  Deschide pagina cursului →
+                </a>
+              </div>
+            ) : null}
           </div>
         ))}
       </div>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,5 +1,7 @@
 import { prisma } from "@lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 async function getCounts() {
   try {
     const [specialties, conditions, procedures, courses] = await Promise.all([

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, Suspense, useState } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 
-export default function LoginPage() {
+function LoginForm() {
   const router = useRouter();
   const params = useSearchParams();
   const [email, setEmail] = useState("");
@@ -71,5 +71,13 @@ export default function LoginPage() {
         Nu ai cont? <a href="/request-access" style={{ color: "#2563eb", fontWeight: 600 }}>Cere acces</a>
       </div>
     </main>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={<main>Se încarcă…</main>}>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/procedures/page.tsx
+++ b/apps/web/src/app/procedures/page.tsx
@@ -1,15 +1,17 @@
 import { prisma } from "@lib/prisma";
+import type { Prisma } from "@prisma/client";
 
 async function getData(q: string | null, limit = 200) {
   try {
-    const where = q
+    const insensitive: Prisma.QueryMode = "insensitive";
+    const where: Prisma.ProcedureWhereInput | undefined = q
       ? {
           OR: [
-            { name: { contains: q, mode: "insensitive" } },
-            { slug: { contains: q, mode: "insensitive" } }
+            { name: { contains: q, mode: insensitive } },
+            { slug: { contains: q, mode: insensitive } }
           ]
         }
-      : {};
+      : undefined;
     const [items, total] = await Promise.all([
       prisma.procedure.findMany({
         where,

--- a/apps/web/src/app/request-access/page.tsx
+++ b/apps/web/src/app/request-access/page.tsx
@@ -1,7 +1,7 @@
 import { prisma } from "@lib/prisma";
 import { revalidatePath } from "next/cache";
 
-async function submit(formData: FormData) {
+async function submit(formData: FormData): Promise<void> {
   "use server";
   const email = String(formData.get("email") || "").trim().toLowerCase();
   const name = String(formData.get("name") || "").trim() || null;
@@ -11,7 +11,7 @@ async function submit(formData: FormData) {
   const source = String(formData.get("source") || "").trim() || null;
 
   if (!email) {
-    return { ok: false, error: "email obligatoriu" };
+    return;
   }
 
   await prisma.requestAccess.create({
@@ -22,7 +22,6 @@ async function submit(formData: FormData) {
   });
 
   revalidatePath("/request-access");
-  return { ok: true };
 }
 
 export default function RequestAccessPage() {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -20,7 +20,8 @@
     "baseUrl": ".",
     "paths": {
       "@lib/*": ["src/lib/*"]
-    }
+    },
+    "esModuleInterop": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- remove the pgcrypto extension requirement from the Prisma schema, add the missing user enrollments relation, and keep Prisma client generation working in build environments without Postgres extensions
- tighten server actions and search filters across the admin/author pages by returning `Promise<void>`, using typed `Prisma` where inputs, and mark those routes as dynamic so builds no longer require a live database
- clean up ancillary configuration (drop experimental server actions, enable `esModuleInterop`, type the AI message mapper, and wrap the login page in a Suspense boundary) so TypeScript checks pass and client components behave correctly

## Testing
- npm run build *(emits warnings because the local DATABASE_URL points at a non-existent host, but the build finishes successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68c92ff1c8fc832a9d7007e6642e705d